### PR TITLE
 [merge/kkyuheak] FIX:  🚨 회원정보 수정페이지 오류 수정, 유저페이지 팔로우 실시간 적용

### DIFF
--- a/Loopin/src/components/common/Following.vue
+++ b/Loopin/src/components/common/Following.vue
@@ -4,22 +4,28 @@ import { useAuthStore } from "@/stores/authStore";
 import { twMerge } from "tailwind-merge";
 import { onBeforeMount, ref } from "vue";
 
-const props = defineProps(["text", "css", "userId"]);
+const props = defineProps(["text", "css", "userData"]);
+
+const userData = ref({
+  id: props.userData.id,
+  followers: props.userData.followers,
+  following: props.userData.following,
+});
 
 const authStore = useAuthStore();
 const { loginUser, updateUser } = authStore;
 
 const isFollowing = ref(false);
 onBeforeMount(() => {
-  console.log(props.userId);
-  if (loginUser && loginUser.following?.includes(props.userId)) {
+  console.log(userData.value);
+  if (loginUser && loginUser.following?.includes(props.userData.id)) {
     isFollowing.value = true;
   } else {
     isFollowing.value = false;
   }
 });
 
-const toggleFollow = async (userId) => {
+const toggleFollow = async (userData) => {
   if (!loginUser) {
     alert("로그인이 필요합니다.");
     return;
@@ -28,41 +34,66 @@ const toggleFollow = async (userId) => {
   let updatedFollowing = loginUser.following || [];
 
   if (isFollowing.value) {
-    updatedFollowing = updatedFollowing.filter((id) => id !== userId);
+    updatedFollowing = updatedFollowing.filter((id) => id !== userData.id);
   } else {
-    updatedFollowing.push(userId);
+    updatedFollowing.push(userData.id);
   }
 
-  const { data, error } = await supabase
+  // 내 유저 팔로잉 db 업데이트
+  const { data: loginUserUpdate, error: loginUserError } = await supabase
     .from("userinfo")
     .update({ following: updatedFollowing })
     .eq("id", loginUser.id)
     .select()
     .single();
-  console.log(data);
-  if (error) {
-    console.error("팔로잉 오류", error.message);
+  console.log("loginUserUpdate", loginUserUpdate);
+  if (loginUserError) {
+    console.error("팔로잉 오류", loginUserError.message);
     return;
   }
 
-  // loginUser.following = updatedFollowing;
-  updateUser(data);
+  updateUser({ following: updatedFollowing });
+  console.log(loginUser);
+
+  // 팔로잉한 유저 팔로우db 업데이트
+  let updatedFollwer = userData.followers || [];
+
+  if (isFollowing.value) {
+    updatedFollwer = updatedFollwer.filter((id) => id !== loginUser.id);
+  } else {
+    updatedFollwer.push(loginUser.id);
+  }
+
+  const { data: followerUserUpdate, error: followerUserError } = await supabase
+    .from("userinfo")
+    .update({ followers: updatedFollwer })
+    .eq("id", userData.id)
+    .select()
+    .single();
+
+  console.log(followerUserUpdate);
+  if (followerUserError) {
+    console.error("상대방 팔로워 오류", followerUserError.message);
+  }
+  userData.followers = updatedFollwer;
+
   isFollowing.value = !isFollowing.value;
 };
 </script>
 <template>
   <button
-    @click="toggleFollow(props.userId)"
+    @click="toggleFollow(props.userData)"
     :class="
       twMerge(
         `${
           isFollowing
             ? `border border-[#F43630] text-[#F43630] text-[15px]
-              hover:bg-[#f43630] hover:text-white transition-all duration-300 ease-out`
+              hover:bg-[#f43630] hover:text-white transition-all duration-200 ease-out`
             : `bg-[#F43630]  text-white border border-[#F43630]
-            hover:bg-white hover:text-[#F43630] transition-all duration-300 ease-in`
+            hover:bg-white hover:text-[#F43630] transition-all duration-200 ease-in`
         } 
         w-[65px] h-[30px] rounded-[25px]`,
+        props.css,
       )
     "
   >

--- a/Loopin/src/main.js
+++ b/Loopin/src/main.js
@@ -16,10 +16,11 @@ pinia.use(piniaPluginPersistedstate);
 app.use(pinia);
 app.use(router);
 app.use(Vue3Toastify, {
-  autoClose: 3000,
+  autoClose: 2800,
   position: toast.POSITION.TOP_CENTER,
   hideProgressBar: true,
   multiple: true,
+  clearOnUrlChange: false,
 });
 
 app.mount("#app");

--- a/Loopin/src/stores/authStore.js
+++ b/Loopin/src/stores/authStore.js
@@ -15,6 +15,7 @@ export const useAuthStore = defineStore(
 
     const updateUser = (updateValue) => {
       loginUser.value = { ...loginUser.value, ...updateValue };
+      console.log(loginUser.value, "authStore");
     };
 
     const deleteUser = (deleteValue) => {

--- a/Loopin/src/views/ProfileEdit.vue
+++ b/Loopin/src/views/ProfileEdit.vue
@@ -53,7 +53,7 @@ const isConfirm = ref(false);
 
 const checkNickname = async (newNickname) => {
   if (newNickname === loginUser.nickname) {
-    isConfirm.value = true;
+    // isConfirm.value = true;
     return;
   }
   try {
@@ -89,12 +89,21 @@ const isCheckPw = ref(true);
 // 유효성 검사 함수
 const validatePassword = (password) => passwordRegex.test(password);
 
+// 프로필변경 업데이트 요청함수
 const updateProfile = async () => {
+  if (
+    newNickname.value === loginUser.nickname &&
+    newDesc.value === loginUser.description &&
+    !image.value &&
+    !newPassword.value.length &&
+    !checkNewPassword.value.length
+  ) {
+    return router.push("/profile");
+  }
+
   // 닉네임 중복확인
   if (newNickname.value !== loginUser.nickname && !isConfirm.value) {
     return toast.warn("닉네임 중복확인을 해주세요!");
-  } else {
-    isConfirm.value = true;
   }
 
   // 비밀번호 확인
@@ -157,7 +166,7 @@ const updateProfile = async () => {
     description: userUpdate.description,
     profile_img: userUpdate.profile_img,
   });
-  toast("변경이 완료되었습니다!");
+  toast.success("변경이 완료되었습니다!");
   router.push("/profile");
 };
 
@@ -216,7 +225,6 @@ const cancelUpdate = () => {
                   <input
                     type="text"
                     v-model="newNickname"
-                    :disabled="isKakao"
                     :class="
                       twMerge(
                         'w-[250px] px-4 py-2 border border-gray-300 rounded-lg outline-none',
@@ -228,7 +236,6 @@ const cancelUpdate = () => {
                     v-if="!isConfirm"
                     type="button"
                     @click="checkNickname(newNickname)"
-                    :disabled="isKakao"
                     class="px-4 py-2 bg-[#F43630] text-white font-medium rounded-lg hover:bg-[#E02E28] transition-colors disabled:opacity-50"
                   >
                     중복 확인

--- a/Loopin/src/views/UserInfoView.vue
+++ b/Loopin/src/views/UserInfoView.vue
@@ -25,7 +25,7 @@ watch(
   async (newPath) => {
     if (newPath === "/profile") {
       isMyPage.value = true;
-    } else {
+    } else if (newPath.split("/")[1] === "user") {
       isMyPage.value = false;
     }
     isLoading.value = true;
@@ -46,15 +46,15 @@ const infos = computed(() => {
   return [
     {
       name: "팔로워",
-      value: isMyPage.value ? loginUser.followers.length || 0 : userData.value?.followers.length || 0,
+      value: isMyPage.value ? loginUser.followers.length || 0 : userData.value.followers.length || 0,
     },
     {
       name: "팔로잉",
-      value: isMyPage.value ? loginUser.following.length || 0 : userData.value?.following.length || 0,
+      value: isMyPage.value ? loginUser.following.length || 0 : userData.value.following.length || 0,
     },
     {
       name: "피드",
-      value: isMyPage.value ? loginUser.posts?.length || 0 : userData.value?.posts.length || 0,
+      value: isMyPage.value ? loginUser.posts.length || 0 : userData.value.posts.length || 0,
     },
   ];
 });
@@ -159,6 +159,7 @@ const fetchData = async () => {
 };
 
 onBeforeMount(() => {
+  console.log(loginUser);
   if (loginUser && decodeURIComponent(route.path.split("/")[2]) === loginUser.nickname) {
     router.replace("/profile");
   }
@@ -257,7 +258,7 @@ const handleShare = () => {
         </button>
 
         <!-- 로그인한 유저만 보임 -->
-        <Following v-else-if="!isMyPage && loginUser && userData" :userId="userData.id" />
+        <Following v-else-if="!isMyPage && loginUser && userData" :userData="userData" />
       </div>
 
       <!-- 피드 정보 -->


### PR DESCRIPTION
회원 정보 수정할 때 닉네임을 변경하지 않았는데도 사용가능합니다! 멘트 나오는 오류 수정했습니다!

유저페이지에서 팔로우를 했을 경우, 팔로워 숫자가 실시간으로 증가 하도록 했습니다. 감소하는 것도 진행했습니다.